### PR TITLE
Add Missing Linker Flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(OS),Darwin)
     LIBS = -lcgraph -llapack -lcdt libsfdp.a -framework GLUT -framework OpenGL -framework Cocoa
 else
     CC = gcc
-    LIBS = -lcgraph -llapack -lcdt libsfdp.a -lGL -lglut -lGLU
+    LIBS = -lcgraph -llapack -lcdt libsfdp.a -lGL -lglut -lGLU -lm -lblas
 endif
 
 CFLAGS = -O2


### PR DESCRIPTION
On Slackware 14.1 -lm and -lblas are needed to link properly
